### PR TITLE
Feature/goal progress list

### DIFF
--- a/ddd/goal-management-system/GoalManager.sln
+++ b/ddd/goal-management-system/GoalManager.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31815.197
@@ -60,8 +59,16 @@ Global
 		{C9751CB7-4CD6-4633-A99A-4F6ADD525437}.Release|x86.Build.0 = Release|Any CPU
 		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Debug|x86.Build.0 = Debug|Any CPU
 		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|x64.Build.0 = Release|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{28607C7D-4B96-4C11-8018-24383BA1D7F3}.Release|x86.Build.0 = Release|Any CPU
 		{4548EB20-1D1B-477B-AF6E-DD55653A6583}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4548EB20-1D1B-477B-AF6E-DD55653A6583}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4548EB20-1D1B-477B-AF6E-DD55653A6583}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/ddd/goal-management-system/src/GoalManager.Core/GoalManagement/GoalSet.cs
+++ b/ddd/goal-management-system/src/GoalManager.Core/GoalManagement/GoalSet.cs
@@ -62,7 +62,7 @@ public class GoalSet : EntityBase, IAggregateRoot
     }
 
     var totalPercentage = GetGoalsTotalPercentage();
-    if ((totalPercentage-goal.Percentage) + percentage > 100)
+    if ((totalPercentage - goal.Percentage) + percentage > 100)
     {
       return Result.Error($"Total percentage of goals cannot exceed 100. Current total percentage is {totalPercentage}");
     }
@@ -82,5 +82,13 @@ public class GoalSet : EntityBase, IAggregateRoot
       return Result.Error($"Goal not found for id: {goalId}");
 
     return goal.AddProgress(actualValue, comment, status);
+  }
+  public Result UpdateGoalStatus(int goalId, GoalProgressStatus status, string? comment = null)
+  {
+    var goal = _goals.FirstOrDefault(g => g.Id == goalId);
+    if (goal == null)
+      return Result.Error($"Goal not found for id: {goalId}");
+
+    return goal.UpdateProgressStatus(status, comment);
   }
 }

--- a/ddd/goal-management-system/src/GoalManager.Infrastructure/Data/AppDbContext.cs
+++ b/ddd/goal-management-system/src/GoalManager.Infrastructure/Data/AppDbContext.cs
@@ -1,4 +1,5 @@
-﻿using GoalManager.Core.Notification;
+﻿using GoalManager.Core.GoalManagement;
+using GoalManager.Core.Notification;
 using GoalManager.Core.Organisation;
 
 using SmartEnum.EFCore;
@@ -17,7 +18,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options,
   public DbSet<TeamMember> TeamMember => Set<TeamMember>();
 
   public DbSet<NotificationItem> NotificationItem => Set<NotificationItem>();
-
+  public DbSet<GoalSet> GoalSet => Set<GoalSet>();
+  public DbSet<Goal> Goal => Set<Goal>();
+  public DbSet<GoalProgress> GoalProgress => Set<GoalProgress>();
   protected override void OnModelCreating(ModelBuilder modelBuilder)
   {
     base.OnModelCreating(modelBuilder);

--- a/ddd/goal-management-system/src/GoalManager.Infrastructure/Data/Queries/GoalManagement/GoalManagementQueryService.cs
+++ b/ddd/goal-management-system/src/GoalManager.Infrastructure/Data/Queries/GoalManagement/GoalManagementQueryService.cs
@@ -1,7 +1,60 @@
-﻿using GoalManager.UseCases.GoalManagement;
+﻿using GoalManager.Core.GoalManagement;
+using GoalManager.Core.Organisation;
+using GoalManager.UseCases.GoalManagement;
+using GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+using GoalManager.UseCases.Organisation;
+using Microsoft.EntityFrameworkCore;
 
 namespace GoalManager.Infrastructure.Data.Queries.GoalManagement;
 
-public sealed class GoalManagementQueryService : IGoalManagementQueryService
+public sealed class GoalManagementQueryService(AppDbContext appDbContext, IOrganisationQueryService organisationQueryService) : IGoalManagementQueryService
 {
+  public async Task<List<PendingApprovalGoalDto>> GetPendingApprovalGoalsForTeamLeader(int teamLeaderUserId)
+  {
+    var teamMembers = await organisationQueryService.GetTeamMemberUserIdsByTeamLeader(teamLeaderUserId);
+    if (!teamMembers.Any()) return [];
+
+    var userIds = teamMembers.Keys.ToList();
+    var teamIds = teamMembers.SelectMany(x => x.Value).Distinct().ToList();
+
+    var results = await (
+        from goal in appDbContext.Goal
+        join goalSet in appDbContext.GoalSet on goal.GoalSetId equals goalSet.Id
+        where userIds.Contains(goalSet.UserId)
+           && teamIds.Contains(goalSet.TeamId)
+        let latestProgress = goal.GoalProgressHistory
+            .Where(p => p.Status == GoalProgressStatus.WaitingForApproval)
+            .OrderByDescending(p => p.Id)
+            .FirstOrDefault()
+        where latestProgress != null
+        select new
+        {
+          GoalId = goal.Id,
+          goal.Title,
+          goal.GoalValue.MinValue,
+          goal.GoalValue.MaxValue,
+          latestProgress.ActualValue,
+          latestProgress.Comment,
+          goalSet.UserId,
+          goalSet.TeamId,
+          GoalSetId = goalSet.Id
+        })
+        .ToListAsync();
+
+    var teamNamesDict = await organisationQueryService.GetTeamNamesAsync(teamIds);
+
+    return results.Select(x => new PendingApprovalGoalDto
+    {
+      GoalId = x.GoalId,
+      GoalSetId = x.GoalSetId,
+      GoalTitle = x.Title,
+      MinValue = x.MinValue,
+      MaxValue = x.MaxValue,
+      ActualValue = x.ActualValue,
+      Comment = x.Comment,
+      GoalOwnerUserId = x.UserId,
+      TeamId = x.TeamId,
+      TeamName = teamNamesDict.TryGetValue(x.TeamId, out var name) ? name : "Unknown Team"
+    }).ToList();
+  }
 }

--- a/ddd/goal-management-system/src/GoalManager.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/ddd/goal-management-system/src/GoalManager.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using GoalManager.Core.Organisation;
 using GoalManager.Infrastructure.Data;
+using GoalManager.Infrastructure.Data.Queries.GoalManagement;
 using GoalManager.Infrastructure.Data.Queries.Notification;
 using GoalManager.Infrastructure.Data.Queries.Organisation;
 using GoalManager.Infrastructure.Identity;
+using GoalManager.UseCases.GoalManagement;
 using GoalManager.UseCases.Identity;
 using GoalManager.UseCases.Notification;
 using GoalManager.UseCases.Organisation;
@@ -26,7 +28,8 @@ public static class InfrastructureServiceExtensions
       .AddScoped<IIdentityRepository, IdentityRepository>()
       .AddScoped<IOrganisationQueryService, OrganisationQueryService>()
       .AddScoped<INotificationQueryService, NotificationQueryService>()
-      .AddScoped<IOrganisationService, OrganisationService>();
+      .AddScoped<IOrganisationService, OrganisationService>()
+      .AddScoped<IGoalManagementQueryService, GoalManagementQueryService>();
 
     logger.LogInformation("{Project} services registered", "Infrastructure");
 

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/GetPendingApprovalGoalsQuery.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/GetPendingApprovalGoalsQuery.cs
@@ -1,0 +1,2 @@
+﻿namespace GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+public record GetPendingApprovalGoalsQuery(int TeamLeaderUserId) : IQuery<List<PendingApprovalGoalDto>>;

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/GetPendingApprovalGoalsQueryHandler.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/GetPendingApprovalGoalsQueryHandler.cs
@@ -1,0 +1,9 @@
+﻿namespace GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+public sealed class GetPendingApprovalGoalsQueryHandler(IGoalManagementQueryService goalQueryService)
+    : IQueryHandler<GetPendingApprovalGoalsQuery, List<PendingApprovalGoalDto>>
+{
+  public Task<List<PendingApprovalGoalDto>> Handle(GetPendingApprovalGoalsQuery request, CancellationToken cancellationToken)
+  {
+    return goalQueryService.GetPendingApprovalGoalsForTeamLeader(request.TeamLeaderUserId);
+  }
+}

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/PendingApprovalGoalDto.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/GetPendingApprovalGoals/PendingApprovalGoalDto.cs
@@ -1,0 +1,14 @@
+﻿namespace GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+public record PendingApprovalGoalDto
+{
+  public int TeamId { get; set; }
+  public string TeamName { get; set; } = null!;
+  public int GoalId { get; set; }
+  public int GoalSetId { get; set; }
+  public string GoalTitle { get; set; } = null!;
+  public int MinValue { get; set; }
+  public int MaxValue { get; set; }
+  public int GoalOwnerUserId { get; set; }
+  public int ActualValue { get; set; }
+  public string? Comment { get; set; }
+}

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/IGoalManagementQueryService.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/IGoalManagementQueryService.cs
@@ -1,4 +1,8 @@
-﻿namespace GoalManager.UseCases.GoalManagement;
+﻿using GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+
+namespace GoalManager.UseCases.GoalManagement;
 public interface IGoalManagementQueryService
 {
+  Task<List<PendingApprovalGoalDto>> GetPendingApprovalGoalsForTeamLeader(int teamLeaderUserId);
+
 }

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/UpdateGoalStatusCommand/UpdateGoalStatusCommand.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/UpdateGoalStatusCommand/UpdateGoalStatusCommand.cs
@@ -1,0 +1,8 @@
+﻿using GoalManager.Core.GoalManagement;
+
+namespace GoalManager.UseCases.GoalManagement.UpdateGoalStatusCommand;
+public record UpdateGoalStatusCommand(
+    int GoalSetId,
+    int GoalId,
+    GoalProgressStatus Status,
+    string? Comment = null) : ICommand<Result>;

--- a/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/UpdateGoalStatusCommand/UpdateGoalStatusCommandHandler.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/GoalManagement/UpdateGoalStatusCommand/UpdateGoalStatusCommandHandler.cs
@@ -1,0 +1,26 @@
+﻿using GoalManager.Core.GoalManagement.Specifications;
+using GoalManager.Core.GoalManagement;
+using GoalManager.Core;
+
+namespace GoalManager.UseCases.GoalManagement.UpdateGoalStatusCommand;
+public sealed class UpdateGoalStatusCommandHandler(IRepository<GoalSet> goalSetRepository)
+    : ICommandHandler<UpdateGoalStatusCommand, Result>
+{
+  public async Task<Result> Handle(UpdateGoalStatusCommand request, CancellationToken cancellationToken)
+  {
+    var goalSet = await goalSetRepository.SingleOrDefaultAsync(
+        new GoalSetWithGoalsByGoalSetIdSpec(request.GoalSetId), cancellationToken);
+
+    if (goalSet == null)
+      return Result.Error($"GoalSet not found: {request.GoalSetId}");
+
+    var result = goalSet.UpdateGoalStatus(request.GoalId, request.Status, request.Comment);
+
+    if (!result.IsSuccess)
+      return result.ToResult();
+
+    await goalSetRepository.UpdateAsync(goalSet, cancellationToken);
+
+    return Result.Success(result);
+  }
+}

--- a/ddd/goal-management-system/src/GoalManager.UseCases/Organisation/IOrganisationQueryService.cs
+++ b/ddd/goal-management-system/src/GoalManager.UseCases/Organisation/IOrganisationQueryService.cs
@@ -13,4 +13,7 @@ public interface IOrganisationQueryService
   Task<string?> GetTeamNameAsync(int id);
 
   Task<List<UserTeamListItemDto>> ListUserTeams(int userId);
+  Task<Dictionary<int, List<int>>> GetTeamMemberUserIdsByTeamLeader(int teamLeaderUserId);
+  Task<Dictionary<int, string>> GetTeamNamesAsync(List<int> teamIds);
+
 }

--- a/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/PendingGoals.cshtml
+++ b/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/PendingGoals.cshtml
@@ -1,0 +1,126 @@
+﻿@page
+@model GoalManager.Web.Pages.GoalManagement.PendingGoalsModel
+@{
+	ViewData["Title"] = "Pending Goals";
+	var groupedGoals = Model.PendingGoals.GroupBy(x => x.TeamName);
+}
+
+<div class="container py-4">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<div>
+			<h1 class="h3 fw-light mb-0">Pending Goals for Approval</h1>
+		</div>
+	</div>
+
+	<alert-messages error-messages="Model.ErrorMessages" success-messages="Model.SuccessMessages"></alert-messages>
+
+	@if (!Model.PendingGoals.Any())
+	{
+		<div class="card border-0 shadow-sm text-center py-5">
+			<i class="fas fa-tasks fa-3x text-muted mb-3"></i>
+			<h3 class="h5 fw-normal">No pending goals</h3>
+			<p class="text-muted mb-4">There are currently no goals awaiting approval.</p>
+		</div>
+	}
+	else
+	{
+		<div class="card border-0 shadow-sm">
+			<div class="table-responsive">
+				<table class="table table-hover mb-0">
+					<thead class="bg-light">
+						<tr>
+							<th class="border-0">Team</th>
+							<th class="border-0">Goal Title</th>
+							<th class="border-0">User</th>
+							<th class="border-0 text-center">Progress</th>
+							<th class="border-0">Comment</th>
+							<th class="border-0 text-end">Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var goal in Model.PendingGoals)
+						{
+							<tr>
+								<td class="align-middle">
+									<span class="badge bg-light text-dark">@goal.TeamName</span>
+								</td>
+								<td class="align-middle">
+									<div class="text-truncate" style="max-width: 200px;" title="@goal.GoalTitle">
+										@goal.GoalTitle
+									</div>
+								</td>
+								<td class="align-middle">
+									<small class="text-muted">ID: @goal.GoalOwnerUserId</small>
+								</td>
+								<td class="align-middle text-center">
+									<div class="d-flex align-items-center gap-2">
+										<span>@goal.ActualValue</span>
+										<div class="progress flex-grow-1" style="height: 6px;">
+											<div class="progress-bar bg-warning"
+												 style="width: @CalculatePercentage(goal.MinValue, goal.MaxValue, goal.ActualValue)%"></div>
+										</div>
+									</div>
+								</td>
+								<td class="align-middle">
+									<div class="text-truncate" style="max-width: 150px;" title="@goal.Comment">
+										@(string.IsNullOrEmpty(goal.Comment) ? "-" : goal.Comment)
+									</div>
+								</td>
+								<td class="align-middle text-end">
+									<div class="d-flex justify-content-end gap-2">
+										<form asp-page-handler="Approve" method="post">
+											<input type="hidden" name="goalSetId" value="@goal.GoalSetId" />
+											<input type="hidden" name="goalId" value="@goal.GoalId" />
+											<button type="submit" class="btn btn-sm btn-outline-success">
+												<i class="fas fa-check"></i> Approve
+											</button>
+										</form>
+										<form asp-page-handler="Reject" method="post">
+											<input type="hidden" name="goalSetId" value="@goal.GoalSetId" />
+											<input type="hidden" name="goalId" value="@goal.GoalId" />
+											<button type="submit" class="btn btn-sm btn-outline-danger"
+													onclick="return confirm('Reject this goal?')">
+												<i class="fas fa-times"></i> Reject
+											</button>
+										</form>
+									</div>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	}
+</div>
+
+@functions {
+	private int CalculatePercentage(decimal min, decimal max, decimal actual)
+	{
+		if (max <= min) return 0;
+		var percentage = (actual - min) / (max - min) * 100;
+		return (int)Math.Clamp(percentage, 0, 100);
+	}
+}
+
+<style>
+	.text-truncate {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.table td, .table th {
+		vertical-align: middle;
+	}
+
+	.progress {
+		min-width: 80px;
+		background-color: #e9ecef;
+	}
+
+	.badge {
+		padding: 0.35em 0.65em;
+		font-size: 0.875em;
+	}
+</style>

--- a/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/PendingGoals.cshtml.cs
+++ b/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/PendingGoals.cshtml.cs
@@ -1,0 +1,56 @@
+﻿using GoalManager.Core.GoalManagement;
+using GoalManager.UseCases.GoalManagement.GetPendingApprovalGoals;
+using GoalManager.UseCases.GoalManagement.UpdateGoalStatusCommand;
+using GoalManager.Web.Common;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GoalManager.Web.Pages.GoalManagement;
+
+[Authorize]
+public class PendingGoalsModel(IMediator mediator) : PageModelBase
+{
+  public List<PendingApprovalGoalDto> PendingGoals { get; private set; } = [];
+
+  public async Task<IActionResult> OnGetAsync()
+  {
+    var user = HttpContext.GetUserContext();
+
+    PendingGoals = await mediator.Send(new GetPendingApprovalGoalsQuery(user.Id));
+
+    return Page();
+  }
+  public async Task<IActionResult> OnPostApproveAsync(int goalSetId, int goalId)
+  {
+    var command = new UpdateGoalStatusCommand(
+        goalSetId,
+        goalId,
+        GoalProgressStatus.Approved);
+
+    var result = await mediator.Send(command);
+
+    if (result.IsSuccess)
+      SuccessMessages.Add("Goal approved successfully");
+    else
+      ErrorMessages.Add("Couldnt Update");
+
+    return RedirectToPage();
+  }
+
+  public async Task<IActionResult> OnPostRejectAsync(int goalSetId, int goalId)
+  {
+    var command = new UpdateGoalStatusCommand(
+        goalSetId,
+        goalId,
+        GoalProgressStatus.Rejected);
+
+    var result = await mediator.Send(command);
+
+    if (result.IsSuccess)
+      SuccessMessages.Add("Goal rejected");
+    else
+      ErrorMessages.Add("Couldnt Update");
+
+    return RedirectToPage();
+  }
+}

--- a/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/TeamGoals.cshtml
+++ b/ddd/goal-management-system/src/GoalManager.Web/Pages/GoalManagement/TeamGoals.cshtml
@@ -21,6 +21,9 @@
 		<div class="mb-4">
 			@foreach (var goal in Model.GoalSet.Goals)
 			{
+				var latestStatus = goal.GoalProgressHistory
+				.OrderByDescending(p => p.Id)
+				.FirstOrDefault()?.Status.ToString() ?? "No Status";
 				<div class="card mb-3">
 					<div class="card-body">
 						<div class="d-flex justify-content-between align-items-start mb-3">
@@ -28,11 +31,15 @@
 							   asp-route-goalSetId="@goal.GoalSetId"
 							   asp-route-goalId="@goal.Id"
 							   class="text-decoration-none text-reset w-100">
-								<div class="d-flex justify-content-between align-items-center w-100">
+								<div class="d-flex justify-content-between align-items-start mb-3">
 									<h5 class="mb-1 fw-normal">@goal.Title</h5>
-									<span class="badge bg-light text-dark ms-2">@goal.GoalType.Name</span>
+									<div class="d-flex align-items-center gap-2">
+										<span class="badge @(GetBadgeStyle(latestStatus))">
+											@latestStatus
+										</span>
+										<span class="badge bg-light text-dark">@goal.GoalType.Name</span>
+									</div>
 								</div>
-
 								<div class="row g-3 mb-3">
 									<div class="col-md-3">
 										<div class="text-muted small">Percentage</div>
@@ -105,6 +112,18 @@
 <script>
 	function updateSliderValue(slider) {
 		document.getElementById('sliderValue-' + slider.closest('.card').id).textContent = slider.value;
+	}
+	@functions {
+		string GetBadgeStyle(string status)
+		{
+			return status switch
+			{
+				"WaitingForApproval" => "bg-warning text-dark",
+				"Approved" => "bg-success text-white",
+				"Rejected" => "bg-danger text-white",
+				_ => "bg-secondary text-white" // Varsayılan durum
+			};
+		}
 	}
 </script>
 

--- a/ddd/goal-management-system/src/GoalManager.Web/Pages/Shared/_Layout.cshtml
+++ b/ddd/goal-management-system/src/GoalManager.Web/Pages/Shared/_Layout.cshtml
@@ -34,6 +34,7 @@
                                 <li class="nav-item"><a aria-current="page" asp-page="/Organisation/List" title="Organisation" class="nav-link">Organisation</a></li>
                                 <li class="nav-item"><a aria-current="page" asp-page="/Notification/List" title="Notifications" class="nav-link">Notifications</a></li>
                                 <li class="nav-item"><a aria-current="page" asp-page="/GoalManagement/Goals" title="Goals" class="nav-link">Goals</a></li>
+								<li class="nav-item"><a aria-current="page" asp-page="/GoalManagement/PendingGoals" title="Goals" class="nav-link">Pending Goals</a></li>
                             </ul>
                         }
                     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/04fbc7ab-c90d-4540-a190-9cb1c3d46733)
Hedef belirleme sayfasında hedefin durumunu gösteriyoruz.
GoalProgress eklerken-güncellerken history'i tamamen siliyoruz. Sadece tabloda son kayıt oluyor.(Silmek yerine Tabloya ISDELETED gibi bir flag eklenebilir.)
![image](https://github.com/user-attachments/assets/e22a7f99-e8b7-46ce-983f-5044255b6c8b)
Login olmuş kullanıcının idsi üzerinden lead olduğu takımlar içerisinde onay bekleyen hedefleri listeliyoruz. Onaylama ve reddetme işlemlerini yapıyor.